### PR TITLE
Add GitHub Action to assign PR milestones from linked issues

### DIFF
--- a/.github/workflows/assign-pr-milestone.yml
+++ b/.github/workflows/assign-pr-milestone.yml
@@ -1,0 +1,121 @@
+name: Assign PR Milestone
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  assign-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Copy milestone from linked issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            if (!pr) {
+              core.setFailed("This workflow must run from a pull request event.");
+              return;
+            }
+
+            if (pr.milestone) {
+              core.info(
+                `PR #${pr.number} already has milestone "${pr.milestone.title}" (#${pr.milestone.number}); leaving it unchanged.`
+              );
+              return;
+            }
+
+            const query = `
+              query ($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 100) {
+                      nodes {
+                        number
+                        title
+                        repository {
+                          nameWithOwner
+                        }
+                        milestone {
+                          number
+                          title
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: pr.number
+            });
+
+            const linkedIssues =
+              result.repository.pullRequest.closingIssuesReferences.nodes ?? [];
+            const currentRepo = `${context.repo.owner}/${context.repo.repo}`;
+
+            if (linkedIssues.length === 0) {
+              core.info(`PR #${pr.number} does not close any linked issues.`);
+              return;
+            }
+
+            const milestoneByNumber = new Map();
+
+            for (const issue of linkedIssues) {
+              if (issue.repository.nameWithOwner !== currentRepo) {
+                core.info(
+                  `Ignoring cross-repo linked issue ${issue.repository.nameWithOwner}#${issue.number}.`
+                );
+                continue;
+              }
+
+              if (!issue.milestone) {
+                core.info(`Linked issue #${issue.number} has no milestone.`);
+                continue;
+              }
+
+              milestoneByNumber.set(issue.milestone.number, issue.milestone.title);
+            }
+
+            if (milestoneByNumber.size === 0) {
+              core.info(`No linked issues for PR #${pr.number} have a milestone.`);
+              return;
+            }
+
+            if (milestoneByNumber.size > 1) {
+              const milestones = [...milestoneByNumber.entries()]
+                .map(([number, title]) => `"${title}" (#${number})`)
+                .join(", ");
+
+              core.info(
+                `PR #${pr.number} closes issues from multiple milestones: ${milestones}. Skipping assignment.`
+              );
+              return;
+            }
+
+            const [milestoneNumber, milestoneTitle] = [...milestoneByNumber.entries()][0];
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              milestone: milestoneNumber
+            });
+
+            core.info(
+              `Assigned milestone "${milestoneTitle}" (#${milestoneNumber}) to PR #${pr.number}.`
+            );


### PR DESCRIPTION
Close #113 

Future PRs - Use closing keywords in the PR description, like `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`

# Automate PR Milestone Assignment

## Summary
- Yes, GitHub Actions can assign a milestone to a pull request automatically.
- In this repo, the cleanest default is: copy the milestone from the issue the PR closes.
- Add a separate workflow so existing CI in `.github/workflows/gradle.yml` stays unchanged.

## Implementation Changes
- Add `.github/workflows/assign-pr-milestone.yml`.
- Trigger on `pull_request_target` for `opened`, `edited`, `reopened`, `synchronize`, and `ready_for_review`.
- Use minimal permissions: `contents: read` and `issues: write`.
- Implement the job with `actions/github-script` only; do not check out PR code.
- Workflow behavior:
  - Read the PR’s closing issue references.
  - If the PR already has a milestone, leave it unchanged.
  - If no linked issue has a milestone, do nothing.
  - If all linked issues with milestones resolve to one distinct milestone, assign that milestone to the PR.
  - If linked issues resolve to different milestones, skip assignment and log a clear message.

## Interfaces
- No application code changes.
- The control interface is the PR body: use normal closing keywords like `Fixes #123` or `Closes #123`.
- The source of truth for milestone choice is the linked issue’s milestone.

## Test Plan
- PR closes one issue with a milestone: PR gets that milestone.
- PR closes one issue without a milestone: PR stays unset.
- PR closes multiple issues with the same milestone: PR gets that milestone.
- PR closes multiple issues with different milestones: workflow skips assignment.
- PR already has a manually set milestone: workflow does not overwrite it.
- Forked PR: workflow still works because it uses `pull_request_target` without checking out PR code.

## Assumptions
- Milestones are managed on issues before PRs are opened.
- Manual milestone assignment on the PR should win over automation.
- If you later want a different rule, the same workflow can be changed to branch-based, label-based, or fixed-release assignment before falling back to linked issues.
