### PR TITLE
Stop resetting filtered person list on update and diagnosis

### DIFF
--- a/src/main/java/seedu/clinic/model/ModelManager.java
+++ b/src/main/java/seedu/clinic/model/ModelManager.java
@@ -110,13 +110,11 @@ public class ModelManager implements Model {
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
         clinicBook.setPerson(target, editedPerson);
-        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
     public void addDiagnosis(Patient target, Diagnosis diagnosis) {
         clinicBook.addDiagnosis(target, diagnosis);
-        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     //=========== Filtered Person List Accessors =============================================================


### PR DESCRIPTION
Run `get-history nric/S1234567D` then `diagnosis id/1 desc/Flu vd/2026-03-01 diagnosed/2 sym/fever sym/cough med/Paracetamol dose/500mg freq/3 times daily dispensed/4`, the filtered list remain

Fix #165 

<img width="878" height="676" alt="image" src="https://github.com/user-attachments/assets/3d0e7cd3-4910-4f91-b63f-4fce4f1a5aca" />
