### PR TITLE
Fix person card text wrapping

### DIFF
--- a/src/main/java/seedu/clinic/ui/PersonCard.java
+++ b/src/main/java/seedu/clinic/ui/PersonCard.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import seedu.clinic.model.person.Patient;
 import seedu.clinic.model.person.Person;
@@ -55,9 +56,13 @@ public class PersonCard extends UiPart<Region> {
         super(FXML);
         this.person = person;
 
-        rowNumber.setText(displayedIndex + ".");
+        rowNumber.setText("Index " + displayedIndex + ".");
         personIdLabel.setText("(ID: " + person.getId() + ")");
+        role.setText(person.getRole());
         name.setText(person.getName().fullName);
+        allowWrapping(name);
+        HBox.setHgrow(name, Priority.ALWAYS);
+        keepFullyVisible(role);
         if (person instanceof Patient) {
             nric.setText("NRIC: " + ((Patient) person).getNric().value);
         } else {
@@ -67,12 +72,23 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
-        role.setText(person.getRole());
+        allowWrapping(address);
+        allowWrapping(email);
 
         if (person instanceof Patient patient) {
             patient.getAllergies().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         }
+    }
+
+    private static void allowWrapping(Label label) {
+        label.setWrapText(true);
+        label.setMinWidth(0);
+        label.setMaxWidth(Double.MAX_VALUE);
+    }
+
+    private static void keepFullyVisible(Label label) {
+        label.setMinWidth(Region.USE_PREF_SIZE);
     }
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -19,7 +19,7 @@
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
       <HBox spacing="6" alignment="CENTER_LEFT">
-        <Label fx:id="rowNumber" styleClass="cell_big_label" text="1.">
+        <Label fx:id="rowNumber" styleClass="cell_big_label" text="Index 1.">
           <!-- Ensures that the label text is never truncated -->
           <minWidth>
             <Region fx:constant="USE_PREF_SIZE" />


### PR DESCRIPTION
- [x] Fix #262 
- [x] Fix #275 

## Summary
- Wrap long names, addresses, and emails in person cards
- Keep role labels fully visible so they do not collapse to ellipses
- Display row numbers as `Index n.` while preserving stable `(ID: n)`

<img width="753" height="685" alt="image" src="https://github.com/user-attachments/assets/a3b0c017-f918-4b88-a7ee-99aa53ddaa4b" />

Long name

<img width="1003" height="750" alt="image" src="https://github.com/user-attachments/assets/03c30b18-00d5-4877-a087-9e0e8cdba354" />
