### PR TITLE
Remove stable wording from stable ID in User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -89,9 +89,9 @@ Shows a list of all persons in the clinic book.
 
 Format: `list`
 
-* Each card shows both the displayed row number and the person's stable `ID`.
-* Use the row number for index-based commands such as `delete`.
-* Use the stable `ID` for commands that reference a specific person record, such as `diagnosis`.
+* Each card shows both the displayed index and the person's `ID`.
+* Use the displayed index for index-based commands such as `delete`.
+* Use the person `ID` for commands that reference a specific person record, such as `diagnosis`.
 
 ### Locating persons by name, phone, or NRIC: `find`
 
@@ -179,7 +179,7 @@ Deletes the specified person from the clinic book.
 Format: `delete INDEX`
 
 * Deletes the person at the specified `INDEX`.
-* The index refers to the index number shown in the displayed person list, not the ID.
+* The index refers to the displayed index shown in the person list, not the ID.
 * The index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
@@ -188,12 +188,12 @@ Examples:
 
 ### Adding a diagnosis : `diagnosis`
 
-Adds a diagnosis to a patient and validates the referenced doctor and pharmacist by stable person `ID`.
+Adds a diagnosis to a patient and validates the referenced doctor and pharmacist by person `ID`.
 
 Format:
 `diagnosis id/PATIENT_ID desc/DESCRIPTION vd/VISIT_DATE diagnosed/DOCTOR_ID sym/SYMPTOM... med/MEDICATION dose/DOSAGE freq/FREQUENCY dispensed/PHARMACIST_ID [med/MEDICATION dose/DOSAGE freq/FREQUENCY dispensed/PHARMACIST_ID]...`
 
-* `id/`, `diagnosed/`, and `dispensed/` use the stable person `ID` shown on each person card, not the displayed row number.
+* `id/`, `diagnosed/`, and `dispensed/` use the person `ID` shown on each person card, not the displayed index.
 * `id/` must refer to a patient, `diagnosed/` must refer to a doctor, and `dispensed/` must refer to a pharmacist.
 * `vd/` must be in `yyyy-MM-dd` format.
 * `id/`, `desc/`, `vd/`, and `diagnosed/` are required.
@@ -206,13 +206,13 @@ Example:
 
 ### Ordering a lab or imaging test : `ordertest`
 
-Orders a lab or imaging test for a patient, referencing the ordering doctor by stable person `ID`.
+Orders a lab or imaging test for a patient, referencing the ordering doctor by person `ID`.
 
 Format:
 `ordertest id/PATIENT_ID test/TEST_NAME testtype/TEST_TYPE vd/ORDER_DATE ordered/DOCTOR_ID`
 
-* `id/` must refer to a patient's stable person `ID`.
-* `ordered/` must refer to a doctor's stable person `ID`.
+* `id/` must refer to a patient's `ID`.
+* `ordered/` must refer to a doctor's `ID`.
 * `test/` is the name of the test (e.g. `Complete Blood Count`, `Chest X-Ray`).
 * `testtype/` must be either `LAB` or `IMAGING` (case-insensitive).
 * `vd/` is the date the order is placed, in `yyyy-MM-dd` format.

--- a/src/main/java/seedu/clinic/logic/commands/AddDiagnosisCommand.java
+++ b/src/main/java/seedu/clinic/logic/commands/AddDiagnosisCommand.java
@@ -67,7 +67,7 @@ public class AddDiagnosisCommand extends Command {
 
     /**
      * Creates an AddDiagnosisCommand to add the specified {@code Diagnosis}
-     * to the patient with the given stable person ID.
+     * to the patient with the given person ID.
      */
     public AddDiagnosisCommand(int patientId, Diagnosis diagnosis) {
         requireNonNull(diagnosis);

--- a/src/main/java/seedu/clinic/logic/commands/OrderTestCommand.java
+++ b/src/main/java/seedu/clinic/logic/commands/OrderTestCommand.java
@@ -49,7 +49,7 @@ public class OrderTestCommand extends Command {
 
     /**
      * Creates an OrderTestCommand to order the specified {@code LabTest}
-     * for the patient with the given stable person ID.
+     * for the patient with the given person ID.
      */
     public OrderTestCommand(int patientId, LabTest labTest) {
         requireNonNull(labTest);

--- a/src/main/java/seedu/clinic/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/clinic/logic/parser/CliSyntax.java
@@ -6,7 +6,7 @@ package seedu.clinic.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_ID = new Prefix("id/"); // stable person ID
+    public static final Prefix PREFIX_ID = new Prefix("id/"); // person ID
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_NRIC = new Prefix("nric/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");

--- a/src/main/java/seedu/clinic/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/clinic/logic/parser/ParserUtil.java
@@ -45,7 +45,7 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code personId} into a stable person ID and returns it. Leading and trailing whitespaces will be
+     * Parses {@code personId} into a person ID and returns it. Leading and trailing whitespaces will be
      * trimmed.
      *
      * @throws ParseException if the specified ID is invalid (not non-zero unsigned integer).


### PR DESCRIPTION
Fix #274 
Close #233 

## Summary
- Replace "stable ID" wording with simpler person ID terminology
- Clarify that `delete` uses the displayed index, not the person ID
- Update related Java comments to match the User Guide terminology